### PR TITLE
Testing library wrapper

### DIFF
--- a/testkit/README.md
+++ b/testkit/README.md
@@ -64,3 +64,40 @@ func Test_removeNthFromEnd(t *testing.T) {
 	}
 }
 ```
+
+## Using the TestKit
+
+```go
+package leetcode
+
+import (
+	"testing"
+  "github.com/jasonherngwang/dsa-go/testkit"
+)
+
+func Add(a int, b int) int {
+	return a + b
+}
+
+func Test_Add(t *testing.T) {
+	type input struct {
+		a int
+		b int
+	}
+
+	tests := []testkit.TestCase[input]{
+		{
+			Name:     "1 + 2",
+			Args:     input{1, 2},
+			Expected: 3,
+		},
+	}
+
+	Run_Tests(t, tests, func(test testkit.TestCase[input]) {
+		actual := Add(test.Args.a, test.Args.b)
+		testkit.Equal(t, actual, test.Expected)
+	})
+}
+```
+
+*Create a VSCode template snippet for easier usage*

--- a/testkit/testing.go
+++ b/testkit/testing.go
@@ -1,0 +1,22 @@
+package testkit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Include desired assertions in exports
+var Equal = assert.Equal
+
+type TestCase[Input any] struct {
+	Name     string
+	Args     Input
+	Expected any
+}
+
+func Run_Tests[Input any](t *testing.T, tests []TestCase[Input], testFunc func(TestCase[Input])) {
+	for _, test := range tests {
+		t.Run(test.Name, func(*testing.T) { testFunc(test) })
+	}
+}


### PR DESCRIPTION
Resolves #2 

Didn't end up streamlining as much as I want. I wanted to end up with a single function that would just accept the `funcToTest` and a set of `testCases`, but after playing around with this for way too long I realized that it just wouldn't work because the `funcToTest` could have arbitrary argument counts, making it impossible to statically type (unless I'm missing something).

@jasonherngwang let me know if you're able to use this alright. 